### PR TITLE
fix: update workflows for yarn and fix release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
+          node-version: '20'
+          cache: 'yarn'
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Fixes

- Update release workflow to use yarn instead of npm
- Fix node version to 20
- Disable yofix workflow until Firebase is configured
- Use local action to avoid missing version errors

This should fix the failing release workflows.