### PR TITLE
Fix: Restore npm install --production for v1.0.20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -221,12 +221,12 @@ runs:
         echo "📦 Installing runtime dependencies..."
         cd ${{ github.action_path }}
         
-        # Install native modules that were externalized during build
-        # Using npm for compatibility with GitHub Actions environment
-        npm install sharp@0.33.0 tree-sitter@0.21.1 tree-sitter-typescript@0.23.2 tree-sitter-javascript@0.23.1 --no-save --production
+        # Install only production dependencies including all externalized modules
+        # This restores the v1.0.17 approach which was working
+        npm install --production --ignore-scripts
         
-        # Rebuild sharp to ensure correct binaries for the runtime platform
-        npm rebuild sharp
+        # Rebuild native modules to ensure correct binaries
+        npm rebuild
         
         echo "✅ Runtime dependencies installed"
         


### PR DESCRIPTION
## 🔧 Critical Fix for v1.0.20

This fixes the runtime dependency installation issue that was causing YoFix to fail in GitHub Actions.

### Problem
v1.0.20 changed from `npm install --production` to only installing specific modules, but missed `playwright` and `firebase-admin` which are required at runtime.

### Solution  
Restore the v1.0.17 approach of using `npm install --production --ignore-scripts` which installs ALL production dependencies.

### Impact
- ✅ Fixes the "Cannot find module" errors
- ✅ All externalized modules are properly installed
- ✅ Native binaries are rebuilt for the target platform

### Testing
The v1.0.20 tag has been force-updated with this fix.