### PR TITLE
fix: properly handle API key initialization in browser-agent

### DIFF
--- a/src/bot/CommandHandler.ts
+++ b/src/bot/CommandHandler.ts
@@ -511,10 +511,9 @@ npx yofix generate-tests --pr ${context.prNumber}
         headless: false,
         maxSteps: 10,
         llmProvider: 'anthropic',
-        viewport: { width: 1920, height: 1080 }
+        viewport: { width: 1920, height: 1080 },
+        apiKey: this.claudeApiKey
       });
-
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
 
       // Execute browser automation
       await this.browserAgent.initialize();

--- a/src/browser-agent/core/Agent.ts
+++ b/src/browser-agent/core/Agent.ts
@@ -58,8 +58,8 @@ export class Agent {
     this.stateManager = new StateManager(task);
     this.promptBuilder = new PromptBuilder();
     
-    // Initialize LLM provider
-    const apiKey = process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY || '';
+    // Initialize LLM provider - prefer options.apiKey over environment variables
+    const apiKey = this.options.apiKey || process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY || '';
     this.llmProvider = this.createLLMProvider(apiKey);
     
     // Initialize planning and reliability components

--- a/src/browser-agent/types/index.ts
+++ b/src/browser-agent/types/index.ts
@@ -103,6 +103,7 @@ export interface AgentOptions {
   timeout?: number;
   llmProvider?: 'openai' | 'anthropic' | 'custom';
   llmModel?: string;
+  apiKey?: string;
   debug?: boolean;
   plugins?: string[];
   useVisionMode?: boolean;

--- a/src/core/analysis/VisualAnalyzer.ts
+++ b/src/core/analysis/VisualAnalyzer.ts
@@ -37,10 +37,9 @@ export class VisualAnalyzer {
         headless: true,
         maxSteps: routes.length * 5, // 5 steps per route
         llmProvider: 'anthropic',
+        apiKey: this.claudeApiKey,
         viewport: { width: 1920, height: 1080 }
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();
@@ -154,10 +153,9 @@ export class VisualAnalyzer {
       const agent = new Agent(analysisTask, {
         headless: true,
         maxSteps: 5,
-        llmProvider: 'anthropic'
+        llmProvider: 'anthropic',
+        apiKey: this.claudeApiKey
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       
@@ -213,10 +211,9 @@ export class VisualAnalyzer {
         const agent = new Agent(fixTask, {
           headless: true,
           maxSteps: 5,
-          llmProvider: 'anthropic'
+          llmProvider: 'anthropic',
+          apiKey: this.claudeApiKey
         });
-        
-        process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
         
         await agent.initialize();
         const result = await agent.run();
@@ -407,10 +404,9 @@ export class VisualAnalyzer {
       const agent = new Agent(explanationTask, {
         headless: true,
         maxSteps: 3,
-        llmProvider: 'anthropic'
+        llmProvider: 'anthropic',
+        apiKey: this.claudeApiKey
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();

--- a/src/core/testing/TestGenerator.ts
+++ b/src/core/testing/TestGenerator.ts
@@ -56,11 +56,9 @@ export class TestGenerator {
         headless: true,
         maxSteps: 25,
         llmProvider: 'anthropic',
-        viewport: this.viewports[0] || { width: 1920, height: 1080 }
+        viewport: this.viewports[0] || { width: 1920, height: 1080 },
+        apiKey: this.claudeApiKey
       });
-      
-      // Set API key
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();
@@ -189,10 +187,9 @@ Provide detailed analysis and practical fixes for any issues found.`;
       const agent = new Agent(authTask, {
         headless: true,
         maxSteps: 15,
-        llmProvider: 'anthropic'
+        llmProvider: 'anthropic',
+      apiKey: this.claudeApiKey
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();
@@ -244,10 +241,9 @@ Provide detailed analysis and practical fixes for any issues found.`;
     const agent = new Agent(testPlanTask, {
       headless: true,
       maxSteps: 50,
-      llmProvider: 'anthropic'
+      llmProvider: 'anthropic',
+    apiKey: this.claudeApiKey
     });
-    
-    process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
     
     try {
       await agent.initialize();

--- a/src/core/testing/VisualIssueTestGenerator.ts
+++ b/src/core/testing/VisualIssueTestGenerator.ts
@@ -101,10 +101,9 @@ export class VisualIssueTestGenerator {
         headless: true,
         maxSteps: 15,
         llmProvider: 'anthropic',
+        apiKey: this.claudeApiKey,
         viewport: { width: 1920, height: 1080 }
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();
@@ -146,10 +145,9 @@ export class VisualIssueTestGenerator {
         headless: true,
         maxSteps: 20,
         llmProvider: 'anthropic',
+        apiKey: this.claudeApiKey,
         viewport: { width: 1920, height: 1080 }
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();

--- a/src/core/testing/VisualRunner.ts
+++ b/src/core/testing/VisualRunner.ts
@@ -63,10 +63,9 @@ export class VisualRunner {
         headless: true,
         maxSteps: template.actions.length + 10, // Extra steps for validation
         llmProvider: 'anthropic',
-        viewport: template.viewport || { width: 1920, height: 1080 }
+        viewport: template.viewport || { width: 1920, height: 1080 },
+        apiKey: this.claudeApiKey
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();

--- a/src/github/SmartAuthHandler.ts
+++ b/src/github/SmartAuthHandler.ts
@@ -61,11 +61,9 @@ export class SmartAuthHandler {
       const agent = new Agent(loginTask, {
         headless: true,
         maxSteps: 10,
-        llmProvider: 'anthropic'
+        llmProvider: 'anthropic',
+      apiKey: this.claudeApiKey
       });
-      
-      // Set API key
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();
@@ -126,10 +124,9 @@ export class SmartAuthHandler {
       const agent = new Agent(logoutTask, {
         headless: true,
         maxSteps: 5,
-        llmProvider: 'anthropic'
+        llmProvider: 'anthropic',
+      apiKey: this.claudeApiKey
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       await agent.run();
@@ -180,10 +177,9 @@ export class SmartAuthHandler {
         headless: true,
         maxSteps: 15,
         llmProvider: 'anthropic',
-        viewport: { width: 1920, height: 1080 }
+        viewport: { width: 1920, height: 1080 },
+        apiKey: this.claudeApiKey
       });
-      
-      process.env.ANTHROPIC_API_KEY = this.claudeApiKey;
       
       await agent.initialize();
       const result = await agent.run();


### PR DESCRIPTION
- Add apiKey option to AgentOptions interface
- Pass API key through constructor options instead of environment variable
- Update all Agent instantiations to use apiKey option
- This ensures API key is available when LLM provider is created
- Fixes 'Could not resolve authentication method' error